### PR TITLE
add cache cleanup option

### DIFF
--- a/deployer.sh
+++ b/deployer.sh
@@ -417,7 +417,10 @@ build() {
 	fi
 
 	#clean first
-	rm -f -r ./.deployer_cache ./build
+	if [ "$skip_cache_cleanup" != "true" ]; then
+		rm -f -r ./.deployer_cache
+	fi
+	rm -f -r ./build
 
 	mkdir -p ${version_folder}
 

--- a/settings_deployer.template
+++ b/settings_deployer.template
@@ -67,6 +67,9 @@ hard_coded_bundle_version_code=""
 # Local resource cache folder for deployer script. This folder will be added to gitignore if exists
 resource_cache_local=".deployer_cache"
 
+# Skip cleanup of .deployer_cache for CI environments where cache is managed externally
+skip_cache_cleanup=false
+
 # If true, add `-l yes` build param for publish live content
 is_live_content=false
 


### PR DESCRIPTION
we dont want to do them every time on release builds on CI, because it undoes the value of using the github actions cache data between runs

this allows github actions to set the param to skip cleaning the cache.